### PR TITLE
Minor updates

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,6 +1,1 @@
-module.exports = {
-  hooks: {
-    ...require('@jupiterone/typescript-tools/config/husky'),
-    "precommit": "yarn rewrite-imports --dir . && lint-staged"
-  }
-};
+module.exports = require('@jupiterone/typescript-tools/config/husky');

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 
 Project Risk Analysis and Reporting Tool
 
-This is a standalone CLI tool intended to analyze the overall risk profile
-for the currently-checked-out branch of a code repository. It will draw risk
+This is a standalone CLI tool intended to analyze the overall risk profile for
+the currently-checked-out branch of a code repository. It will draw risk
 information from a configurable list of sources, including JupiterOne, before
 rendering an overall risk verdict for the code.
 
 Use-cases include:
 
-* CI/CD gates
-* Local development and remediation
-* Security analysis and code review
+- CI/CD gates
+- Local development and remediation
+- Security analysis and code review
 
 ## Usage
 
@@ -57,16 +57,17 @@ docker run -v $PWD:/app -e 'J1_API_TOKEN=<token>' -e 'J1_ACCOUNT=<accountname>' 
 
 `peril` assumes that:
 
-* You are using `git`.
-* The present working directory is the top-level of the git project to be analyzed, or the `--dir` flag points to this top-level.
+- You are using `git`.
+- The present working directory is the top-level of the git project to be
+  analyzed, or the `--dir` flag points to this top-level.
 
 ## Risk Scores
 
 The Risk scores that `peril` produces are arbitrary. A more structured
 calculation--the
 [DREAD](https://en.wikipedia.org/wiki/DREAD_%28risk_assessment_model%29)
-model--was considered but abandoned since that model lacks academic rigor and
-is difficult to apply in a consistent fashion that produces sensible results.
+model--was considered but abandoned since that model lacks academic rigor and is
+difficult to apply in a consistent fashion that produces sensible results.
 Instead, `peril` takes the position that since risk evaluation will always be
 subjective, the values it uses should be inherently arbitrary and easily
 configured for tuning purposes (see below). It is recommended to run `peril`
@@ -80,8 +81,8 @@ tightly with the configured checks/practices.
 
 `peril` ships with default risk values out-of-the-box, but these are all
 configurable. You may override any of the values or facts found in the
-`./test/fixtures/testConfig.ts` file, in JSON format, and specify a path to
-your local config.json override with the `-c` | `--config` flag, e.g.:
+`./test/fixtures/testConfig.ts` file, in JSON format, and specify a path to your
+local config.json override with the `-c` | `--config` flag, e.g.:
 
 ```shell
 peril --config ./path/to/my/config.json
@@ -90,8 +91,8 @@ peril --config ./path/to/my/config.json
 NOTE: it is assumed that this override config file is trusted, and the code
 `peril` is analyzing does not have permissions to write or modify this file!
 
-Additionally, you may provide custom configuration via an executable script
-or program that emits JSON on stdout. The path to this executable may also be
+Additionally, you may provide custom configuration via an executable script or
+program that emits JSON on stdout. The path to this executable may also be
 specified with the `--config` flag. An example script may be found at
 `./test/fixtures/testConfig.sh`. Please ensure that the permissions to this
 script or program are locked down prior to invoking with `peril --config`!
@@ -102,47 +103,53 @@ script or program are locked down prior to invoking with `peril --config`!
 
 Checks related to Git SCM:
 
-| Check | Config Path | Notes |
-| ----- | ----------- | ----- |
-| git   | values.checks.scm.git | I think we can all agree code should be versioned. |
-| enforceGpg | values.checks.scm.enforceGpg | Encourage code-signing at the repo-level. |
-| verifyGpg | values.checks.scm.verifyGpg | Ensure recent commits have been signed. |
+| Check            | Config Path                        | Notes                                                               |
+| ---------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| git              | values.checks.scm.git              | I think we can all agree code should be versioned.                  |
+| enforceGpg       | values.checks.scm.enforceGpg       | Encourage code-signing at the repo-level.                           |
+| verifyGpg        | values.checks.scm.verifyGpg        | Ensure recent commits have been signed.                             |
 | gitleaksFindings | values.checks.scm.gitleaksFindings | Committing sensitive data to git is an information disclosure risk. |
 
 ### CODE
 
 Checks related to the code being analyzed.
 
-| Check | Config Path | Notes |
-| ----- | ----------- | ----- |
-| linesChanged | values.checks.code.linesChanged | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping. |
-| filesChanged | values.checks.code.filesChanged | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping. |
-| depscanFindings | values.checks.code.depscanFindings | 3rd-party dependency vulnerabilities represent a supply-chain risk. `**` |
+| Check           | Config Path                        | Notes                                                                                 |
+| --------------- | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| linesChanged    | values.checks.code.linesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping. |
+| filesChanged    | values.checks.code.filesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping. |
+| depscanFindings | values.checks.code.depscanFindings | 3rd-party dependency vulnerabilities represent a supply-chain risk. `**`              |
 
 ### PROJECT
 
 Checks related to the Project (CodeRepo in JupiterOne).
 
-| Check | Config Path | Notes |
-| ----- | ----------- | ----- |
-| snykFindings | values.checks.project.snykFindings | 3rd-party dependency vulnerabilities represent a supply-chain risk. `++`
-| maintenanceFindings | values.checks.project.maintenanceFindings | Overdue maintenance represents organizational risk. `@@`
-| threatModels | values.checks.project.threatModels | Encourage threat modeling activities. Add risk for unmitigated design flaws. `!!`
+| Check               | Config Path                               | Notes                                                                             |
+| ------------------- | ----------------------------------------- | --------------------------------------------------------------------------------- |
+| snykFindings        | values.checks.project.snykFindings        | 3rd-party dependency vulnerabilities represent a supply-chain risk. `++`          |
+| maintenanceFindings | values.checks.project.maintenanceFindings | Overdue maintenance represents organizational risk. `@@`                          |
+| threatModels        | values.checks.project.threatModels        | Encourage threat modeling activities. Add risk for unmitigated design flaws. `!!` |
 
 #### Legend
 
-| Symbol | Meaning |
-| ------ | ------- |
-| `**`   | Requires local use of [ShiftLeft/sast-scan](https://github.com/ShiftLeftSecurity/sast-scan/) prior to invoking `peril`. |
-| `++`   | Requires the [Snyk integration](https://support.jupiterone.io/hc/en-us/articles/360024788554-Snyk) to be configured for JupiterOne. |
+| Symbol | Meaning                                                                                                                                                    |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `**`   | Requires local use of [ShiftLeft/sast-scan](https://github.com/ShiftLeftSecurity/sast-scan/) prior to invoking `peril`.                                    |
+| `++`   | Requires the [Snyk integration](https://support.jupiterone.io/hc/en-us/articles/360024788554-Snyk) to be configured for JupiterOne.                        |
 | `@@`   | Will add risk if the CodeRepo entity in JupiterOne relates to overdue [`deferred_maintenance`](https://github.com/JupiterOne/deferred-maintenance/) items. |
-| `!!`   | Works with [OWASP Threat Dragon](http://docs.threatdragon.org/) models.
+| `!!`   | Works with [OWASP Threat Dragon](http://docs.threatdragon.org/) models.                                                                                    |
 
 ## Manual Overrides
 
-From time-to-time, it may be necessary or desirable to override the risk calculations `peril` provides. Calling `peril --override` can be used locally to create an override object that may be committed to the `.peril/` folder of the target git repository.
+From time-to-time, it may be necessary or desirable to override the risk
+calculations `peril` provides. Calling `peril --override` can be used locally to
+create an override object that may be committed to the `.peril/` folder of the
+target git repository.
 
-To use this feature, you will need to be a trusted staff member authorized by your business for this purpose. `peril` signs the override files with `gpg`, so your public key will need to be provisioned in advance in CI/CD. See "Trusting pubkeys" below.
+To use this feature, you will need to be a trusted staff member authorized by
+your business for this purpose. `peril` signs the override files with `gpg`, so
+your public key will need to be provisioned in advance in CI/CD. See "Trusting
+pubkeys" below.
 
 ### Generating a local override
 
@@ -155,15 +162,21 @@ To use this feature, you will need to be a trusted staff member authorized by yo
 
 ### Trusting pubkeys in CI/CD
 
-Provision your trusted pubkeys in a directory (in binary format, via `gpg --export`) reachable by `peril` in CI/CD. This directory, and all pubkey files within it MUST NOT be world writable. To enable the override feature, you must invoke `peril` with the `--pubkeyDir` flag, and specify a full path to the trusted pubkey directory you've previously provisioned.
+Provision your trusted pubkeys in a directory (in binary format, via
+`gpg --export`) reachable by `peril` in CI/CD. This directory, and all pubkey
+files within it MUST NOT be world writable. To enable the override feature, you
+must invoke `peril` with the `--pubkeyDir` flag, and specify a full path to the
+trusted pubkey directory you've previously provisioned.
 
-For example, if your pubkeys are available in the `/usr/local/gpgkeys` directory of your CI/CD host, you should specify the following parameter:
+For example, if your pubkeys are available in the `/usr/local/gpgkeys` directory
+of your CI/CD host, you should specify the following parameter:
 
 ```sh-session
 --pubkeyDir /usr/local/gpgkeys
 ```
 
-If using `peril` with `docker`, you will likely need to mount this folder into the container with the `-v` flag.
+If using `peril` with `docker`, you will likely need to mount this folder into
+the container with the `-v` flag.
 
 e.g.:
 

--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -2,17 +2,18 @@
   "riskTolerance": 20,
   "checks": {
     "code": {
-      "linesChanged" : {
+      "linesChanged": {
         "riskStep": 100,
         "riskValuePerStep": 1
       },
-      "filesChanged" : {
+      "filesChanged": {
         "riskStep": 20,
         "riskValuePerStep": 1
       },
-      "depscanFindings" : {
+      "depscanFindings": {
         "ignoreSeverityList": "INFO, LOW",
         "ignoreUnfixable": true,
+        "ignoreIndirects": true,
         "missingValue": 10,
         "noVulnerabilitiesCredit": -5
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/peril",
   "description": "Project Risk Analysis and Reporting Tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "JupiterOne <developer@jupiterone.com>",
   "repository": "jupiterone/project-risk-analyzer",
   "license": "MIT",

--- a/src/code.test.ts
+++ b/src/code.test.ts
@@ -1,11 +1,21 @@
-import { parseGitDiffShortStat, getGitDiffStats, locCheck, filesChangedCheck, depScanCheck, parseShiftLeftDepScan } from './code';
-import { ShortStat } from './types';
+import { cloneDeep } from 'lodash';
 import { depScanFindings } from '../test/fixtures/depscanFindings';
 import { config } from '../test/fixtures/testConfig';
+import {
+  depScanCheck,
+  filesChangedCheck,
+  getGitDiffStats,
+  locCheck,
+  parseGitDiffShortStat,
+  parseShiftLeftDepScan,
+} from './code';
+import { ShortStat } from './types';
 
 describe('code risks', () => {
   it('parseGitDiffShortStat parses git diff stats for numeric values', () => {
-    const parsedOutput = parseGitDiffShortStat(' 9 files changed, 12 insertions(+), 43 deletions(-)');
+    const parsedOutput = parseGitDiffShortStat(
+      ' 9 files changed, 12 insertions(+), 43 deletions(-)'
+    );
     expect(parsedOutput.filesChanged).toEqual(9);
     expect(parsedOutput.linesAdded).toEqual(12);
     expect(parsedOutput.linesRemoved).toEqual(43);
@@ -17,15 +27,21 @@ describe('code risks', () => {
   });
 
   it('getGitDiffStats returns parsed git diff output with sentinel value', async () => {
-    const failedStats = await getGitDiffStats('main', jest.fn().mockResolvedValueOnce({
-      failed: true
-    }));
+    const failedStats = await getGitDiffStats(
+      'main',
+      jest.fn().mockResolvedValueOnce({
+        failed: true,
+      })
+    );
     expect(failedStats.filesChanged).toEqual(-1); // signal failure to caller
 
-    const stats = await getGitDiffStats('main', jest.fn().mockResolvedValueOnce({
-      failed: false,
-      stdout: ' 9 files changed, 12 insertions(+), 43 deletions(-)'
-    }));
+    const stats = await getGitDiffStats(
+      'main',
+      jest.fn().mockResolvedValueOnce({
+        failed: false,
+        stdout: ' 9 files changed, 12 insertions(+), 43 deletions(-)',
+      })
+    );
     expect(stats.filesChanged).toEqual(9);
     expect(stats.linesAdded).toEqual(12);
     expect(stats.linesRemoved).toEqual(43);
@@ -35,14 +51,14 @@ describe('code risks', () => {
     const stats1: ShortStat = {
       filesChanged: 1,
       linesAdded: 100,
-      linesRemoved: 0
+      linesRemoved: 0,
     };
     const risk = await locCheck(stats1, config);
     expect(risk.value).toEqual(1);
     const stats2: ShortStat = {
       filesChanged: 1,
       linesAdded: 300,
-      linesRemoved: 150
+      linesRemoved: 150,
     };
     const risk2 = await locCheck(stats2, config);
     expect(risk2.value).toEqual(1.5);
@@ -52,24 +68,34 @@ describe('code risks', () => {
     const stats1: ShortStat = {
       filesChanged: 10,
       linesAdded: 100,
-      linesRemoved: 100
+      linesRemoved: 100,
     };
     const risk = await filesChangedCheck(stats1, config);
     expect(risk.value).toEqual(0.5);
     const stats2: ShortStat = {
       filesChanged: 40,
       linesAdded: 300,
-      linesRemoved: 150
+      linesRemoved: 150,
     };
     const risk2 = await filesChangedCheck(stats2, config);
     expect(risk2.value).toEqual(2);
   });
 
   it('parseShiftLeftDepScan parses file of newline-delimited JSON strings into DepScanFinding[]', async () => {
-    const reportString = depScanFindings.map(f => JSON.stringify(f)).join('\n');
-    const findings = await parseShiftLeftDepScan('testReport', jest.fn().mockResolvedValueOnce(reportString));
+    const reportString = depScanFindings
+      .map((f) => JSON.stringify(f))
+      .join('\n');
+    const findings = await parseShiftLeftDepScan(
+      'testReport',
+      jest.fn().mockResolvedValueOnce(reportString)
+    );
     expect(findings).toEqual(depScanFindings);
-    expect(await parseShiftLeftDepScan('testReport', jest.fn().mockResolvedValueOnce(''))).toEqual([]);
+    expect(
+      await parseShiftLeftDepScan(
+        'testReport',
+        jest.fn().mockResolvedValueOnce('')
+      )
+    ).toEqual([]);
   });
 
   it('parseShiftLeftDepScan returns empty Array on error/missing report', async () => {
@@ -83,8 +109,18 @@ describe('code risks', () => {
   });
 
   it('depScanCheck ignores risk for <MEDIUM severity or unfixable findings', async () => {
-    const risk = await (depScanCheck(depScanFindings, config));
+    const konfig = cloneDeep(config);
+    konfig.values.checks.code.depscanFindings.ignoreIndirects = false;
+    const risk = await depScanCheck(depScanFindings, konfig);
     expect(risk.value).toEqual(7.5);
     expect(risk.description).toMatch(/1 HIGH/);
+  });
+
+  it('depScanCheck ignores risk for optional/indirect findings if ignoreIndirects is set', async () => {
+    const konfig = cloneDeep(config);
+    konfig.values.checks.code.depscanFindings.ignoreIndirects = true;
+    const risk = await depScanCheck(depScanFindings, konfig);
+    expect(risk.value).toEqual(0);
+    expect(risk.description).toMatch(/None/);
   });
 });

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,8 +1,15 @@
-import { Risk, ShortStat, CodeFacts, MaybeString, DepScanFinding, Config } from './types';
-import { findFiles, runCmd, formatRisk } from './helpers';
-import { getConfig } from './config';
-import path from 'path';
 import * as fs from 'fs-extra';
+import path from 'path';
+import { getConfig } from './config';
+import { findFiles, formatRisk, runCmd } from './helpers';
+import {
+  CodeFacts,
+  Config,
+  DepScanFinding,
+  MaybeString,
+  Risk,
+  ShortStat,
+} from './types';
 
 const riskCategory = 'code';
 
@@ -14,102 +21,143 @@ export function parseGitDiffShortStat(shortStat: string): ShortStat {
 
   if (shortStat.indexOf(',') > 0) {
     // parseFloat, because JavaScript numbers are... special.
-    [ filesChanged, linesAdded, linesRemoved ] = shortStat.split(',').map(parseFloat);
+    [filesChanged, linesAdded, linesRemoved] = shortStat
+      .split(',')
+      .map(parseFloat);
   }
 
   return {
     filesChanged,
     linesAdded,
-    linesRemoved
+    linesRemoved,
   };
 }
 
-export async function getGitDiffStats(mergeRef: string, cmdRunner: any = undefined): Promise<ShortStat> {
+export async function getGitDiffStats(
+  mergeRef: string,
+  cmdRunner: any = undefined
+): Promise<ShortStat> {
   const excludePatterns = ['*.lock', '*.md', '*test*'];
-  const excludeSyntax: string = excludePatterns.reduce((acc: string, p: string): string => {
-    acc += `':(exclude)${p}' `;
-    return acc;
-  }, '');
+  const excludeSyntax: string = excludePatterns.reduce(
+    (acc: string, p: string): string => {
+      acc += `':(exclude)${p}' `;
+      return acc;
+    },
+    ''
+  );
   const cmd = `git diff --ignore-all-space --shortstat ${mergeRef} HEAD -- . ${excludeSyntax}`;
   // git syntax above requires shell to parse.
   // NOTE: this will likely not work on Microsoft Windows.
-  const { stdout: shortstat, failed } = await runCmd(cmd, cmdRunner, {shell: true});
+  const { stdout: shortstat, failed } = await runCmd(cmd, cmdRunner, {
+    shell: true,
+  });
   if (failed) {
     return {
       filesChanged: -1,
       linesAdded: 0,
-      linesRemoved: 0
+      linesRemoved: 0,
     };
   }
   return parseGitDiffShortStat(shortstat);
 }
 
-export async function locCheck(gitStats: ShortStat, config: Config = getConfig()): Promise<Risk> {
+export async function locCheck(
+  gitStats: ShortStat,
+  config: Config = getConfig()
+): Promise<Risk> {
   const check = 'linesChanged';
   const recommendations: string[] = [];
 
   // Simple linear model for positive risk as net new lines of code:
   // Code is a liability. Therefore deletions actually represent (on average), negative risk.
-  const netChangedLOC = (gitStats.linesAdded || 0) - (gitStats.linesRemoved || 0);
+  const netChangedLOC =
+    (gitStats.linesAdded || 0) - (gitStats.linesRemoved || 0);
   const riskLOCStep = config.values.checks.code.linesChanged.riskStep;
-  const riskValuePerStep = config.values.checks.code.linesChanged.riskValuePerStep;
+  const riskValuePerStep =
+    config.values.checks.code.linesChanged.riskValuePerStep;
 
   // scale net changed lines (which may be negative) by a configurable ratio to determine risk value
   const value = netChangedLOC * (riskValuePerStep / riskLOCStep);
 
   if (value > 10) {
-    recommendations.push('Aim for smaller PRs: this makes them easier to review.');
+    recommendations.push(
+      'Aim for smaller PRs: this makes them easier to review.'
+    );
   }
 
-  return formatRisk({
-    check,
-    value,
-    description: `~${netChangedLOC} net lines of changed code.`,
-    recommendations
-  }, riskCategory, check);
+  return formatRisk(
+    {
+      check,
+      value,
+      description: `~${netChangedLOC} net lines of changed code.`,
+      recommendations,
+    },
+    riskCategory,
+    check
+  );
 }
 
-export async function filesChangedCheck(gitStats: ShortStat, config: Config = getConfig()): Promise<Risk> {
+export async function filesChangedCheck(
+  gitStats: ShortStat,
+  config: Config = getConfig()
+): Promise<Risk> {
   const check = 'filesChanged';
   const recommendations: string[] = [];
   // Simple linear model for increased risk due to many files changed (therefore hard to review/reason about).
 
   const riskFilesStep = config.values.checks.code.filesChanged.riskStep;
-  const riskValuePerStep = config.values.checks.code.filesChanged.riskValuePerStep;
+  const riskValuePerStep =
+    config.values.checks.code.filesChanged.riskValuePerStep;
 
   // scale changed files by a configurable ratio to determine risk value
   const value = gitStats.filesChanged * (riskValuePerStep / riskFilesStep);
 
   if (value > 10) {
-    recommendations.push('Change fewer files per PR: this helps your reviewer(s).');
+    recommendations.push(
+      'Change fewer files per PR: this helps your reviewer(s).'
+    );
   }
 
-  return formatRisk({
-    check,
-    value,
-    description: `${gitStats.filesChanged} changed files.`,
-    recommendations
-  }, riskCategory, check);
+  return formatRisk(
+    {
+      check,
+      value,
+      description: `${gitStats.filesChanged} changed files.`,
+      recommendations,
+    },
+    riskCategory,
+    check
+  );
 }
 
-export async function depScanCheck(findings: DepScanFinding[], config: Config = getConfig()): Promise<Risk> {
+export async function depScanCheck(
+  findings: DepScanFinding[],
+  config: Config = getConfig()
+): Promise<Risk> {
   const check = 'depscanFindings';
   const recommendations: string[] = [];
   const {
     missingValue,
     ignoreSeverityList,
     ignoreUnfixable,
-    noVulnerabilitiesCredit
+    ignoreIndirects,
+    noVulnerabilitiesCredit,
   } = config.values.checks.code.depscanFindings;
 
   if (!findings.length) {
-    recommendations.push('Ensure ShiftLeft/scan dependency check runs prior to peril.');
-    return formatRisk({
-      check,
-      description: 'Code - Missing Dependency Scan',
-      value: missingValue,
-      recommendations
-    }, riskCategory, check);
+    recommendations.push(
+      'Ensure ShiftLeft/scan dependency check runs prior to peril.'
+    );
+    return formatRisk(
+      {
+        check,
+        description: 'Code - Missing Dependency Scan',
+        value: missingValue,
+        recommendations,
+      },
+      riskCategory,
+      check
+    );
   }
 
   let value = 0;
@@ -118,13 +166,19 @@ export async function depScanCheck(findings: DepScanFinding[], config: Config = 
     high: 0,
     medium: 0,
     low: 0,
-    info: 0
+    info: 0,
   };
 
-  const ignoreSeverities = ignoreSeverityList.toLowerCase().split(',').map(i => i.trim());
+  const ignoreSeverities = ignoreSeverityList
+    .toLowerCase()
+    .split(',')
+    .map((i) => i.trim());
 
   for (const finding of findings) {
     if (!finding.fix_version && ignoreUnfixable) {
+      continue;
+    }
+    if (finding.package_usage === 'optional' && ignoreIndirects) {
       continue;
     }
     if (ignoreSeverities.includes(finding.severity.toLowerCase())) {
@@ -139,7 +193,7 @@ export async function depScanCheck(findings: DepScanFinding[], config: Config = 
   const validFindingCounts: string[] = [];
   for (const sevKey of Object.keys(sevCounts)) {
     if (sevCounts[sevKey] > 0) {
-        validFindingCounts.push(`${sevCounts[sevKey]} ${sevKey.toUpperCase()}`);
+      validFindingCounts.push(`${sevCounts[sevKey]} ${sevKey.toUpperCase()}`);
     }
   }
   if (!validFindingCounts.length) {
@@ -149,36 +203,51 @@ export async function depScanCheck(findings: DepScanFinding[], config: Config = 
     recommendations.push('Upgrade vulnerable packages.');
   }
 
-  return formatRisk({
-    check,
-    description: validFindingCounts.join(', '),
-    value,
-    recommendations
-  }, riskCategory, check);
+  return formatRisk(
+    {
+      check,
+      description: validFindingCounts.join(', '),
+      value,
+      recommendations,
+    },
+    riskCategory,
+    check
+  );
 }
 
-export async function gatherFacts(cmdRunner: any = undefined, config: Config = getConfig()): Promise<CodeFacts> {
+export async function gatherFacts(
+  cmdRunner: any = undefined,
+  config: Config = getConfig()
+): Promise<CodeFacts> {
   const depScanReportPattern = 'depscan-report.*.json';
   const depScanReportDir = path.join(config.flags.dir, 'reports');
   return {
     code: {
       scans: {
-        depScanReport: (await findFiles(depScanReportDir, depScanReportPattern))[0]
-      }
-    }
+        depScanReport: (
+          await findFiles(depScanReportDir, depScanReportPattern)
+        )[0],
+      },
+    },
   };
 }
 
-export async function parseShiftLeftDepScan(reportFile: MaybeString, readFile: typeof fs.readFile = fs.readFile): Promise<DepScanFinding[]> {
+export async function parseShiftLeftDepScan(
+  reportFile: MaybeString,
+  readFile: typeof fs.readFile = fs.readFile
+): Promise<DepScanFinding[]> {
   const depFindings: DepScanFinding[] = [];
   try {
     const report = await readFile(String(reportFile), 'utf8');
     // each line in report is a stringified JSON finding expression
-    const lines = report.trim().split('\n').filter(l => l.length > 0);
+    const lines = report
+      .trim()
+      .split('\n')
+      .filter((l) => l.length > 0);
     if (!lines.length) {
       return [];
     }
-    lines.map(line => {
+    lines.map((line) => {
       depFindings.push(JSON.parse(line) as DepScanFinding);
     });
   } catch (e) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,13 @@
-import { Config, Facts } from './types';
-import { runCmd, log } from './helpers';
-import * as scm from './scm';
-import * as code from './code';
-import * as jupiterone  from './jupiterone';
-import * as project from './project';
-import * as override from './override';
 import * as fs from 'fs-extra';
-import path from 'path';
 import _ from 'lodash';
+import path from 'path';
+import * as code from './code';
+import { log, runCmd } from './helpers';
+import * as jupiterone from './jupiterone';
+import * as override from './override';
+import * as project from './project';
+import * as scm from './scm';
+import { Config, Facts } from './types';
 
 const executable = require('executable');
 
@@ -24,33 +24,38 @@ export const envConfig = {
   j1AuthToken: _.get(processEnv, 'J1_API_TOKEN'),
   j1Account: _.get(processEnv, 'J1_ACCOUNT'),
   logLevel: _.get(processEnv, 'LOG_LEVEL', 'info'),
-  threatDragonDir: _.get(processEnv, 'THREAT_DRAGON_DIR')
+  threatDragonDir: _.get(processEnv, 'THREAT_DRAGON_DIR'),
 };
 
 async function gatherAllFacts(): Promise<Facts> {
   return {
-    ...await scm.gatherFacts(),
-    ...await code.gatherFacts(),
-    ...await jupiterone.gatherFacts(),
-    ...await project.gatherFacts(),
-    ...await override.gatherFacts()
+    ...(await scm.gatherFacts()),
+    ...(await code.gatherFacts()),
+    ...(await jupiterone.gatherFacts()),
+    ...(await project.gatherFacts()),
+    ...(await override.gatherFacts()),
   };
 }
 
 let config: any = {
   env: envConfig,
-}
+};
 
 export async function initConfig(flags: object) {
   config.flags = flags;
   config.facts = await gatherAllFacts();
-  config.values = JSON.parse(await fs.readFile(path.join(__dirname, '../defaultConfig.json'), 'utf8'));
+  config.values = JSON.parse(
+    await fs.readFile(path.join(__dirname, '../defaultConfig.json'), 'utf8')
+  );
   const optionalConfig = await gatherOptionalConfig();
   // deep merge optional override config into default config
   config = _.merge(config, optionalConfig);
 }
 
-export async function gatherOptionalConfig(config: Config = getConfig(), readFile: typeof fs.readFile = fs.readFile): Promise<Partial<Config>> {
+export async function gatherOptionalConfig(
+  config: Config = getConfig(),
+  readFile: typeof fs.readFile = fs.readFile
+): Promise<Partial<Config>> {
   let optConfig: Partial<Config>;
   if (!config.flags.config) {
     return {};
@@ -72,7 +77,6 @@ export async function gatherOptionalConfig(config: Config = getConfig(), readFil
 
 export function getConfig(): Config {
   if (process.env.NODE_ENV === 'test') {
-    // console.log('getConfig called during tests')
     return require('../test/fixtures/testConfig').config;
   }
   return config;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,16 +23,16 @@ export interface SCMFacts {
     gpgPath: MaybeString;
     scans: {
       gitleaksScanReport: MaybeString;
-    }
-  }
+    };
+  };
 }
 
 export interface CodeFacts {
   code: {
     scans: {
       depScanReport: MaybeString;
-    }
-  }
+    };
+  };
 }
 
 export interface ProjectFacts {
@@ -40,13 +40,13 @@ export interface ProjectFacts {
     name: MaybeString;
     threatDragonModels: MaybeString[];
     threatDragonModelsDir: string;
-  }
+  };
 }
 
 export interface JupiterOneFacts {
   j1: {
     client?: J1Client;
-  }
+  };
 }
 
 export interface OverrideFacts {
@@ -54,10 +54,14 @@ export interface OverrideFacts {
     trustedPubKeysDir: MaybeString;
     trustedPubKeys: string[];
     repoOverrides: string[];
-  }
+  };
 }
 
-export type Facts = SCMFacts & CodeFacts & JupiterOneFacts & ProjectFacts & OverrideFacts;
+export type Facts = SCMFacts &
+  CodeFacts &
+  JupiterOneFacts &
+  ProjectFacts &
+  OverrideFacts;
 
 export interface Config {
   env: {
@@ -69,56 +73,57 @@ export interface Config {
   flags: Flags;
   facts: Facts;
   values: {
-    checks: SCMValues & CodeValues & ProjectValues
+    checks: SCMValues & CodeValues & ProjectValues;
     riskTolerance: number;
-  }
+  };
 }
 
 export interface SCMValues {
   scm: {
     git: {
       missingValue: number;
-    },
+    };
     enforceGpg: {
       missingValue: number;
-    },
+    };
     verifyGpg: {
       missingValue: number;
-    },
+    };
     gitleaksFindings: {
       perFindingValue: number;
-    }
-  }
+    };
+  };
 }
 
 export interface CodeValues {
   code: {
-    linesChanged : {
+    linesChanged: {
       riskStep: number;
       riskValuePerStep: number;
-    },
-    filesChanged : {
+    };
+    filesChanged: {
       riskStep: number;
       riskValuePerStep: number;
-    },
-    depscanFindings : {
+    };
+    depscanFindings: {
       ignoreSeverityList: string;
       ignoreUnfixable: boolean;
+      ignoreIndirects: boolean;
       missingValue: number;
       noVulnerabilitiesCredit: number;
-    }
-  }
+    };
+  };
 }
 
 export interface ProjectValues {
   project: {
     snykFindings: {
       ignoreNonUpgradables: boolean;
-    },
+    };
     maintenanceFindings: {
       daysLateRiskStep: number;
       daysLateRiskValuePerStep: number;
-    },
+    };
     threatModels: {
       enabled: boolean;
       highRiskValue: number;
@@ -126,8 +131,8 @@ export interface ProjectValues {
       lowRiskValue: number;
       allMitigatedCredit: number;
       missingValue: number;
-    }
-  }
+    };
+  };
 }
 export interface Flags {
   verbose: boolean;
@@ -143,8 +148,8 @@ export interface Flags {
 export interface ShortStat {
   filesChanged: number;
   linesAdded: number;
-  linesRemoved: number
-};
+  linesRemoved: number;
+}
 
 export type CodeRepoFinding = SnykFinding | DeferredMaintenanceFinding;
 
@@ -156,8 +161,8 @@ export interface SortedFindings {
 
 export interface DeferredMaintenanceFinding {
   entity: {
-    _type: string[]
-  },
+    _type: string[];
+  };
   properties: {
     weblink: string;
     dueDate: string;
@@ -166,13 +171,13 @@ export interface DeferredMaintenanceFinding {
     createdBy: string;
     closed: boolean;
     lapsedDays?: number;
-  }
+  };
 }
 
 export interface SnykFinding {
   entity: {
-    _type: string[]
-  },
+    _type: string[];
+  };
   properties: {
     category: string;
     score: number;
@@ -187,7 +192,7 @@ export interface SnykFinding {
     severity: string;
     package: string;
     version: string;
-  }
+  };
 }
 
 export interface DepScanFinding {
@@ -209,7 +214,7 @@ export interface GitleaksMetrics {
   low: number;
 }
 
-export type LogLevel = 'INFO' | 'WARN' | 'ERROR' | 'DEBUG'
+export type LogLevel = 'INFO' | 'WARN' | 'ERROR' | 'DEBUG';
 
 export interface LogLevelValues {
   info: string;

--- a/test/fixtures/testConfig.ts
+++ b/test/fixtures/testConfig.ts
@@ -5,7 +5,7 @@ export const config: Config = {
     j1AuthToken: 'REDACTED',
     j1Account: 'j1test',
     logLevel: 'info',
-    threatDragonDir: 'ThreatDragonModels'
+    threatDragonDir: 'ThreatDragonModels',
   },
   flags: {
     verbose: true,
@@ -13,7 +13,9 @@ export const config: Config = {
     mergeRef: 'master',
     config: '/Users/test/repos/jupiterone/peril/testConfig.json',
     debug: false,
-    accept: false
+    accept: false,
+    override: false,
+    pubkeyDir: '',
   },
   facts: {
     scm: {
@@ -23,20 +25,27 @@ export const config: Config = {
       gitPath: '/usr/local/bin/git',
       gpgPath: '/usr/local/bin/gpg',
       scans: {
-        gitleaksScanReport: '/Users/test/repos/jupiterone/peril/reports/credscan-report.sarif'
-      }
+        gitleaksScanReport:
+          '/Users/test/repos/jupiterone/peril/reports/credscan-report.sarif',
+      },
     },
     code: {
       scans: {
-        depScanReport: '/Users/test/repos/jupiterone/peril/reports/depscan-report-nodejs.json'
-      }
+        depScanReport:
+          '/Users/test/repos/jupiterone/peril/reports/depscan-report-nodejs.json',
+      },
     },
     j1: {},
     project: {
-      threatDragonModels: [ __dirname + '/threatDragon.json' ],
+      threatDragonModels: [__dirname + '/threatDragon.json'],
       threatDragonModelsDir: 'ThreatDragonModels',
-      name: 'peril'
-    }
+      name: 'peril',
+    },
+    override: {
+      trustedPubKeysDir: '',
+      trustedPubKeys: [],
+      repoOverrides: [],
+    },
   },
   values: {
     riskTolerance: 20,
@@ -44,50 +53,51 @@ export const config: Config = {
       code: {
         linesChanged: {
           riskStep: 100,
-          riskValuePerStep: 1
+          riskValuePerStep: 1,
         },
         filesChanged: {
           riskStep: 20,
-          riskValuePerStep: 1
+          riskValuePerStep: 1,
         },
         depscanFindings: {
           ignoreSeverityList: 'INFO, LOW',
           ignoreUnfixable: true,
+          ignoreIndirects: true,
           missingValue: 10,
-          noVulnerabilitiesCredit: 0
-        }
+          noVulnerabilitiesCredit: 0,
+        },
       },
       scm: {
         git: {
-          missingValue: 5
+          missingValue: 5,
         },
         enforceGpg: {
-          missingValue: 0.5
+          missingValue: 0.5,
         },
         verifyGpg: {
-          missingValue: 0.5
+          missingValue: 0.5,
         },
         gitleaksFindings: {
-          perFindingValue: 10
-        }
+          perFindingValue: 10,
+        },
       },
       project: {
         snykFindings: {
-          ignoreNonUpgradables: true
+          ignoreNonUpgradables: true,
         },
         maintenanceFindings: {
           daysLateRiskStep: 10,
-          daysLateRiskValuePerStep: 5
+          daysLateRiskValuePerStep: 5,
         },
         threatModels: {
-         enabled: true,
-         highRiskValue: 10,
-         mediumRiskValue: 5,
-         lowRiskValue: 1,
-         allMitigatedCredit: -3,
-         missingValue: 5
-      }
-      }
-    }
-  }
-}
+          enabled: true,
+          highRiskValue: 10,
+          mediumRiskValue: 5,
+          lowRiskValue: 1,
+          allMitigatedCredit: -3,
+          missingValue: 5,
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
Address some previous PR comments.
Adds husky triggers
Support configurable ignore of indirect dependency vulns for sast-scan. e.g.:

![Screen Shot 2021-03-17 at 5 18 57 PM](https://user-images.githubusercontent.com/513523/111540590-b428d480-8745-11eb-9f5c-23a5af86b641.png)

This setting will respect the findings of the sast-scan tool, and not penalize for optional/indirect findings.