### PR TITLE
Show devs which vulnerable packages to update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupiterone/peril",
   "description": "Project Risk Analysis and Reporting Tool",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "JupiterOne <developer@jupiterone.com>",
   "repository": "jupiterone/project-risk-analyzer",
   "license": "MIT",

--- a/src/code.ts
+++ b/src/code.ts
@@ -205,7 +205,9 @@ export async function depScanCheck(
   } else {
     recommendations.push('Upgrade vulnerable packages:');
     for (const finding of validFindings) {
-      recommendations.push(`  - ${finding.package}`);
+      recommendations.push(
+        `  - ${finding.package}@${finding.version} can be upgraded to ${finding.fix_version}`
+      );
     }
   }
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -174,6 +174,8 @@ export async function depScanCheck(
     .split(',')
     .map((i) => i.trim());
 
+  const validFindings: DepScanFinding[] = [];
+
   for (const finding of findings) {
     if (!finding.fix_version && ignoreUnfixable) {
       continue;
@@ -185,6 +187,7 @@ export async function depScanCheck(
       continue;
     }
     value += parseFloat(finding.cvss_score);
+    validFindings.push(finding);
     sevCounts[finding.severity.toLowerCase()] += 1;
   }
 
@@ -200,7 +203,10 @@ export async function depScanCheck(
     validFindingCounts.push('None 🎉');
     value += noVulnerabilitiesCredit;
   } else {
-    recommendations.push('Upgrade vulnerable packages.');
+    recommendations.push('Upgrade vulnerable packages:');
+    for (const finding of validFindings) {
+      recommendations.push(`  - ${finding.package}`);
+    }
   }
 
   return formatRisk(


### PR DESCRIPTION
Since peril filters the output of tools like Snyk and sast-scan, emit these offending packages when run in `--verbose` mode.