### PR TITLE
P#21 Introduces high risk license detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,12 @@ Checks related to Git SCM:
 
 Checks related to the code being analyzed.
 
-| Check           | Config Path                        | Notes                                                                                 |
-| --------------- | ---------------------------------- | ------------------------------------------------------------------------------------- |
-| linesChanged    | values.checks.code.linesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping. |
-| filesChanged    | values.checks.code.filesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping. |
-| depscanFindings | values.checks.code.depscanFindings | 3rd-party dependency vulnerabilities represent a supply-chain risk. `**`              |
+| Check           | Config Path                        | Notes                                                                                                       |
+| --------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| linesChanged    | values.checks.code.linesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping.                       |
+| filesChanged    | values.checks.code.filesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping.                       |
+| depscanFindings | values.checks.code.depscanFindings | 3rd-party dependency vulnerabilities represent a supply-chain risk. `**`                                    |
+| bannedLicenses  | values.checks.code.bannedLicenses  | 3rd-party dependencies that have non-compliant or incompatible licenses represent a supply-chain risk. `**` |
 
 ### PROJECT
 

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ Checks related to Git SCM:
 
 Checks related to the code being analyzed.
 
-| Check           | Config Path                        | Notes                                                                                                       |
-| --------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| linesChanged    | values.checks.code.linesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping.                       |
-| filesChanged    | values.checks.code.filesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping.                       |
-| depscanFindings | values.checks.code.depscanFindings | 3rd-party dependency vulnerabilities represent a supply-chain risk. `**`                                    |
-| bannedLicenses  | values.checks.code.bannedLicenses  | 3rd-party dependencies that have non-compliant or incompatible licenses represent a supply-chain risk. `**` |
+| Check           | Config Path                        | Notes                                                                                                |
+| --------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| linesChanged    | values.checks.code.linesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping.                |
+| filesChanged    | values.checks.code.filesChanged    | Large PRs represent a strain on code reviewers, and increase risk of rubber-stamping.                |
+| depscanFindings | values.checks.code.depscanFindings | 3rd-party dependency vulnerabilities represent a supply-chain risk. `**`                             |
+| bannedLicenses  | values.checks.code.bannedLicenses  | 3rd-party dependencies that have non-compliant or incompatible licenses represent a legal risk. `**` |
 
 ### PROJECT
 

--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -16,6 +16,20 @@
         "ignoreIndirects": true,
         "missingValue": 10,
         "noVulnerabilitiesCredit": -5
+      },
+      "bannedLicenses": {
+        "licenses": [
+          "^GPL",
+          "^LGPL",
+          "^AGPL",
+          "SSPL-1.0",
+          "^CC BY-SA",
+          "MS-RL",
+          "EUPL-1.2",
+          "CC-BY-NC-3.0"
+        ],
+        "missingValue": 10,
+        "noVulnerabilitiesCredit": -5
       }
     },
     "scm": {

--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -29,7 +29,7 @@
           "CC-BY-NC-3.0"
         ],
         "missingValue": 10,
-        "noVulnerabilitiesCredit": -5
+        "noVulnerabilitiesCredit": -1
       }
     },
     "scm": {

--- a/src/code.test.ts
+++ b/src/code.test.ts
@@ -1,11 +1,13 @@
-import { cloneDeep } from 'lodash';
 import { depScanFindings } from '../test/fixtures/depscanFindings';
 import { config } from '../test/fixtures/testConfig';
+import { licenseFindings } from './../test/fixtures/bomReport';
 import {
+  bannedLicensesCheck,
   depScanCheck,
   filesChangedCheck,
   getGitDiffStats,
   locCheck,
+  parseBomLicenses,
   parseGitDiffShortStat,
   parseShiftLeftDepScan,
 } from './code';
@@ -15,6 +17,7 @@ const {
   depscanFindings,
   linesChanged,
   filesChanged,
+  bannedLicenses,
 } = config.values.checks.code;
 
 describe('code risks', () => {
@@ -115,7 +118,7 @@ describe('code risks', () => {
   });
 
   it('depScanCheck ignores risk for <MEDIUM severity or unfixable findings', async () => {
-    const konfig = cloneDeep(depscanFindings);
+    const konfig = Object.assign({}, depscanFindings);
     konfig.ignoreIndirects = false;
     const risk = await depScanCheck(depScanFindings, konfig);
     expect(risk.value).toEqual(7.5);
@@ -123,10 +126,41 @@ describe('code risks', () => {
   });
 
   it('depScanCheck ignores risk for optional/indirect findings if ignoreIndirects is set', async () => {
-    const konfig = cloneDeep(depscanFindings);
+    const konfig = Object.assign({}, depscanFindings);
     konfig.ignoreIndirects = true;
     const risk = await depScanCheck(depScanFindings, konfig);
     expect(risk.value).toEqual(0);
     expect(risk.description).toMatch(/None/);
+  });
+
+  it('parseBomLicenses parses JSON file into LicenseFinding[]', async () => {
+    const reportString = licenseFindings.map((f) => JSON.stringify(f));
+    const findings = await parseBomLicenses(
+      'testReport',
+      jest.fn().mockResolvedValueOnce('{"components": [' + reportString + ']}')
+    );
+    expect(findings).toEqual(licenseFindings);
+    expect(
+      await parseBomLicenses('testReport', jest.fn().mockResolvedValueOnce(''))
+    ).toEqual([]);
+  });
+
+  it('parseBomLicenses returns empty Array on error/missing report', async () => {
+    const findings = await parseBomLicenses(undefined);
+    expect(findings).toEqual([]);
+  });
+
+  it('bannedLicensesCheck penalizes for missing scans', async () => {
+    const missingScanRisk = await bannedLicensesCheck([], bannedLicenses);
+    expect(missingScanRisk.value).toBeGreaterThanOrEqual(1);
+  });
+
+  it('bannedLicensesCheck successfully identifies high risk licenses', async () => {
+    const konfig = Object.assign({}, bannedLicenses);
+    const risk = await bannedLicensesCheck(licenseFindings, konfig);
+    expect(risk.value).toEqual(2000);
+    expect(risk.description).toMatch(
+      'CODE - bannedLicenseFindings: pkg:npm/babel/compat-data@7.13.15, pkg:npm/electron-to-bromium@1.3.713 +2000.00'
+    );
   });
 });

--- a/src/code.test.ts
+++ b/src/code.test.ts
@@ -1,9 +1,6 @@
 import { depScanFindings } from '../test/fixtures/depscanFindings';
 import { config } from '../test/fixtures/testConfig';
-import {
-  badLicenseFindings,
-  goodLicenseFindings,
-} from './../test/fixtures/bomReport';
+import { badLicenses, goodLicenses } from './../test/fixtures/bomReport';
 import {
   bannedLicensesCheck,
   depScanCheck,
@@ -136,21 +133,21 @@ describe('code risks', () => {
     expect(risk.description).toMatch(/None/);
   });
 
-  it('parseBomLicenses parses JSON file into LicenseFinding[]', async () => {
-    const reportString = badLicenseFindings.map((f) => JSON.stringify(f));
-    const findings = await parseBomLicenses(
+  it('parseBomLicenses parses JSON file into BOMLicenses[]', async () => {
+    const reportString = badLicenses.map((f) => JSON.stringify(f));
+    const licenses = await parseBomLicenses(
       'testReport',
       jest.fn().mockResolvedValueOnce('{"components": [' + reportString + ']}')
     );
-    expect(findings).toEqual(badLicenseFindings);
+    expect(licenses).toEqual(badLicenses);
     expect(
       await parseBomLicenses('testReport', jest.fn().mockResolvedValueOnce(''))
     ).toEqual([]);
   });
 
   it('parseBomLicenses returns empty Array on error/missing report', async () => {
-    const findings = await parseBomLicenses(undefined);
-    expect(findings).toEqual([]);
+    const licenses = await parseBomLicenses(undefined);
+    expect(licenses).toEqual([]);
   });
 
   it('bannedLicensesCheck penalizes for missing scans', async () => {
@@ -160,7 +157,7 @@ describe('code risks', () => {
 
   it('bannedLicensesCheck successfully identifies high risk licenses', async () => {
     const konfig = Object.assign({}, bannedLicenses);
-    const risk = await bannedLicensesCheck(badLicenseFindings, konfig);
+    const risk = await bannedLicensesCheck(badLicenses, konfig);
     expect(risk.value).toEqual(2000);
     expect(risk.description).toMatch(
       'CODE - bannedLicenseFindings: pkg:npm/babel/compat-data@7.13.15, pkg:npm/electron-to-bromium@1.3.713 +2000.00'
@@ -169,7 +166,7 @@ describe('code risks', () => {
 
   it('bannedLicensesCheck passes when no high risk licenses are found', async () => {
     const konfig = Object.assign({}, bannedLicenses);
-    const risk = await bannedLicensesCheck(goodLicenseFindings, konfig);
+    const risk = await bannedLicensesCheck(goodLicenses, konfig);
     expect(risk.value).toEqual(-5);
     expect(risk.description).toMatch('None 🎉');
   });

--- a/src/code.test.ts
+++ b/src/code.test.ts
@@ -1,6 +1,9 @@
 import { depScanFindings } from '../test/fixtures/depscanFindings';
 import { config } from '../test/fixtures/testConfig';
-import { licenseFindings } from './../test/fixtures/bomReport';
+import {
+  badLicenseFindings,
+  goodLicenseFindings,
+} from './../test/fixtures/bomReport';
 import {
   bannedLicensesCheck,
   depScanCheck,
@@ -134,12 +137,12 @@ describe('code risks', () => {
   });
 
   it('parseBomLicenses parses JSON file into LicenseFinding[]', async () => {
-    const reportString = licenseFindings.map((f) => JSON.stringify(f));
+    const reportString = badLicenseFindings.map((f) => JSON.stringify(f));
     const findings = await parseBomLicenses(
       'testReport',
       jest.fn().mockResolvedValueOnce('{"components": [' + reportString + ']}')
     );
-    expect(findings).toEqual(licenseFindings);
+    expect(findings).toEqual(badLicenseFindings);
     expect(
       await parseBomLicenses('testReport', jest.fn().mockResolvedValueOnce(''))
     ).toEqual([]);
@@ -157,10 +160,17 @@ describe('code risks', () => {
 
   it('bannedLicensesCheck successfully identifies high risk licenses', async () => {
     const konfig = Object.assign({}, bannedLicenses);
-    const risk = await bannedLicensesCheck(licenseFindings, konfig);
+    const risk = await bannedLicensesCheck(badLicenseFindings, konfig);
     expect(risk.value).toEqual(2000);
     expect(risk.description).toMatch(
       'CODE - bannedLicenseFindings: pkg:npm/babel/compat-data@7.13.15, pkg:npm/electron-to-bromium@1.3.713 +2000.00'
     );
+  });
+
+  it('bannedLicensesCheck passes when no high risk licenses are found', async () => {
+    const konfig = Object.assign({}, bannedLicenses);
+    const risk = await bannedLicensesCheck(goodLicenseFindings, konfig);
+    expect(risk.value).toEqual(-5);
+    expect(risk.description).toMatch('None 🎉');
   });
 });

--- a/src/code.ts
+++ b/src/code.ts
@@ -346,7 +346,7 @@ export async function parseBomLicenses(
 ): Promise<LicenseFinding[]> {
   const licenceFindings: LicenseFinding[] = [];
   try {
-    const reportString = await readFile(reportFile, 'utf8');
+    const reportString = await readFile(String(reportFile), 'utf8');
     const components = JSON.parse(reportString).components;
     // each line in report is a stringified JSON finding expression
     for (const component of components) {

--- a/src/code.ts
+++ b/src/code.ts
@@ -290,7 +290,10 @@ export async function bannedLicensesCheck(
   return formatRisk(
     {
       check,
-      description: invalidMaterials.map((material) => material.purl).join(', '),
+      description:
+        invalidMaterials.length > 0
+          ? invalidMaterials.map((material) => material.purl).join(', ')
+          : 'None 🎉',
       value,
       recommendations,
     },

--- a/src/code.ts
+++ b/src/code.ts
@@ -351,7 +351,7 @@ export async function parseBomLicenses(
   try {
     const reportString = await readFile(String(reportFile), 'utf8');
     const components = JSON.parse(reportString).components;
-    // each line in report is a stringified JSON finding expression
+    // construct LicenseFinding[] from components array in the BOM
     for (const component of components) {
       licenceFindings.push({
         purl: component.purl,

--- a/src/gather.ts
+++ b/src/gather.ts
@@ -68,12 +68,10 @@ export async function codeRisk(): Promise<RiskCategory> {
   );
   checks.push(code.depScanCheck(depScanFindings, cfgValues.depscanFindings));
 
-  const licenseScanFindings = await code.parseBomLicenses(
+  const bomLicenses = await code.parseBomLicenses(
     config.facts.code.scans.bomReport
   );
-  checks.push(
-    code.bannedLicensesCheck(licenseScanFindings, cfgValues.bannedLicenses)
-  );
+  checks.push(code.bannedLicensesCheck(bomLicenses, cfgValues.bannedLicenses));
 
   // gather risks
   const risks = await Promise.all(checks);

--- a/src/gather.ts
+++ b/src/gather.ts
@@ -68,6 +68,13 @@ export async function codeRisk(): Promise<RiskCategory> {
   );
   checks.push(code.depScanCheck(depScanFindings, cfgValues.depscanFindings));
 
+  const licenseScanFindings = await code.parseBomLicenses(
+    config.facts.code.scans.bomReport
+  );
+  checks.push(
+    code.bannedLicensesCheck(licenseScanFindings, cfgValues.bannedLicenses)
+  );
+
   // gather risks
   const risks = await Promise.all(checks);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,7 +235,7 @@ export type DepScanFinding = {
   short_description: string;
 };
 
-export type LicenseFinding = {
+export type BOMLicenses = {
   licenses: License[];
   purl: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export type CodeFacts = {
   code: {
     scans: {
       depScanReport: MaybeString;
+      bomReport: MaybeString;
     };
   };
 };
@@ -108,7 +109,14 @@ export type CodeValues = {
     linesChanged: CodeValuesLinesChangedCheck;
     filesChanged: CodeValuesFileChangedCheck;
     depscanFindings: CodeValuesDepScanCheck;
+    bannedLicenses: CodeValuesBannedLicensesCheck;
   };
+};
+
+export type CodeValuesBannedLicensesCheck = {
+  licenses: string[];
+  missingValue: number;
+  noVulnerabilitiesCredit: number;
 };
 
 export type CodeValuesDepScanCheck = {
@@ -225,6 +233,20 @@ export type DepScanFinding = {
   severity: string;
   cvss_score: string;
   short_description: string;
+};
+
+export type LicenseFinding = {
+  licenses: License[];
+  purl: string;
+};
+
+export type License = {
+  license: LicenseDetails;
+};
+
+export type LicenseDetails = {
+  id: string;
+  url: string;
 };
 
 export type GitleaksMetrics = {

--- a/test/fixtures/bomReport.ts
+++ b/test/fixtures/bomReport.ts
@@ -1,0 +1,59 @@
+import { LicenseFinding } from './../../src/types';
+
+export const licenseFindings: LicenseFinding[] = [
+  {
+    purl: 'pkg:npm/babel/compat-data@7.13.15',
+    licenses: [
+      {
+        license: {
+          id: 'MIT',
+          url: 'https://opensource.org/licenses/MIT',
+        },
+      },
+    ],
+  },
+  {
+    purl: 'pkg:npm/caniuse-lite@1.0.30001208',
+    licenses: [
+      {
+        license: {
+          id: 'CC-BY-4.0',
+          url: 'https://opensource.org/licenses/CC-BY-4.0',
+        },
+      },
+    ],
+  },
+  {
+    purl: 'pkg:npm/electron-to-chromium@1.3.713',
+    licenses: [
+      {
+        license: {
+          id: 'ISC',
+          url: 'https://opensource.org/licenses/ISCq',
+        },
+      },
+    ],
+  },
+  {
+    purl: 'pkg:npm/babel/compat-data@7.13.15',
+    licenses: [
+      {
+        license: {
+          id: 'GPLv2',
+          url: 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html',
+        },
+      },
+    ],
+  },
+  {
+    purl: 'pkg:npm/electron-to-bromium@1.3.713',
+    licenses: [
+      {
+        license: {
+          id: 'MS-RL',
+          url: 'https://opensource.org/licenses/MS-RL',
+        },
+      },
+    ],
+  },
+];

--- a/test/fixtures/bomReport.ts
+++ b/test/fixtures/bomReport.ts
@@ -1,6 +1,6 @@
-import { LicenseFinding } from './../../src/types';
+import { BOMLicenses } from './../../src/types';
 
-export const badLicenseFindings: LicenseFinding[] = [
+export const badLicenses: BOMLicenses[] = [
   {
     purl: 'pkg:npm/babel/compat-data@7.13.15',
     licenses: [
@@ -58,7 +58,7 @@ export const badLicenseFindings: LicenseFinding[] = [
   },
 ];
 
-export const goodLicenseFindings: LicenseFinding[] = [
+export const goodLicenses: BOMLicenses[] = [
   {
     purl: 'pkg:npm/babel/compat-data@7.13.15',
     licenses: [

--- a/test/fixtures/bomReport.ts
+++ b/test/fixtures/bomReport.ts
@@ -1,6 +1,6 @@
 import { LicenseFinding } from './../../src/types';
 
-export const licenseFindings: LicenseFinding[] = [
+export const badLicenseFindings: LicenseFinding[] = [
   {
     purl: 'pkg:npm/babel/compat-data@7.13.15',
     licenses: [
@@ -52,6 +52,42 @@ export const licenseFindings: LicenseFinding[] = [
         license: {
           id: 'MS-RL',
           url: 'https://opensource.org/licenses/MS-RL',
+        },
+      },
+    ],
+  },
+];
+
+export const goodLicenseFindings: LicenseFinding[] = [
+  {
+    purl: 'pkg:npm/babel/compat-data@7.13.15',
+    licenses: [
+      {
+        license: {
+          id: 'MIT',
+          url: 'https://opensource.org/licenses/MIT',
+        },
+      },
+    ],
+  },
+  {
+    purl: 'pkg:npm/caniuse-lite@1.0.30001208',
+    licenses: [
+      {
+        license: {
+          id: 'CC-BY-4.0',
+          url: 'https://opensource.org/licenses/CC-BY-4.0',
+        },
+      },
+    ],
+  },
+  {
+    purl: 'pkg:npm/electron-to-chromium@1.3.713',
+    licenses: [
+      {
+        license: {
+          id: 'ISC',
+          url: 'https://opensource.org/licenses/ISCq',
         },
       },
     ],

--- a/test/fixtures/testConfig.ts
+++ b/test/fixtures/testConfig.ts
@@ -33,6 +33,7 @@ export const config: Config = {
       scans: {
         depScanReport:
           '/Users/test/repos/jupiterone/peril/reports/depscan-report-nodejs.json',
+        bomReport: '/Users/test/repos/jupiterone/peril/reports/bom-nodejs.json',
       },
     },
     j1: {},
@@ -65,6 +66,24 @@ export const config: Config = {
           ignoreIndirects: true,
           missingValue: 10,
           noVulnerabilitiesCredit: 0,
+        },
+        bannedLicenses: {
+          /*
+           * HIGH risk licenses sourced from:
+           * - https://www.synopsys.com/blogs/software-security/top-open-source-licenses/
+           */
+          licenses: [
+            '^GPL',
+            '^LGPL',
+            '^AGPL',
+            'SSPL-1.0',
+            '^CC BY-SA',
+            'MS-RL',
+            'EUPL-1.2',
+            'CC-BY-NC-3.0',
+          ],
+          missingValue: 10,
+          noVulnerabilitiesCredit: -5,
         },
       },
       scm: {


### PR DESCRIPTION
Peril will now inspect the `bom-nodejs.json` for high risk licenses in accordance with this [list of licenses](https://www.synopsys.com/blogs/software-security/top-open-source-licenses/). License IDs follow the [SPDX license identifiers](https://spdx.org/licenses/).

NOTE: Any high risk license hit should result in a failed score, so each match incurs 1000pts
