### PR TITLE
SRE-474 - Add risk for each unsigned commit

### DIFF
--- a/defaultConfig.json
+++ b/defaultConfig.json
@@ -46,6 +46,9 @@
       "verifyGpg": {
         "missingValue": 0.5
       },
+      "verifyAllGpg": {
+        "perUnverifiedValue": 1
+      },
       "gitleaksFindings": {
         "perFindingValue": 10
       }

--- a/src/gather.ts
+++ b/src/gather.ts
@@ -8,7 +8,7 @@ import { Config, Risk, RiskCategory } from './types';
 
 export async function localSCMRisk(): Promise<RiskCategory> {
   const checks: Promise<Risk>[] = [];
-  const defaultRiskValue = 5;
+  const defaultRiskValue = 0;
 
   const config = getConfig();
 
@@ -23,6 +23,12 @@ export async function localSCMRisk(): Promise<RiskCategory> {
   }
   if (config.facts.scm.gitPath && config.facts.scm.gpgPath) {
     checks.push(scm.gpgVerifyRecentCommitsCheck(scmCheckValues.verifyGpg));
+    checks.push(
+      scm.gpgVerifyAllCommitsCheck(
+        config.flags.mergeRef,
+        scmCheckValues.verifyAllGpg
+      )
+    );
   }
 
   checks.push(
@@ -34,6 +40,7 @@ export async function localSCMRisk(): Promise<RiskCategory> {
 
   // gather risks
   const risks = await Promise.all(checks);
+  console.log({ risks, defaultRiskValue, section: 'localSCMRisk' });
 
   return {
     title: 'SCM Risk',

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export type SCMValues = {
     git: SCMValuesGitCheck;
     enforceGpg: SCMValuesEnforceGPGCheck;
     verifyGpg: SCMValuesVerifyGPGCheck;
+    verifyAllGpg: SCMValuesVerifyAllGPGCheck;
     gitleaksFindings: SCMValuesGitleaksFindingsCheck;
   };
 };
@@ -94,6 +95,10 @@ export type SCMValuesEnforceGPGCheck = {
 
 export type SCMValuesVerifyGPGCheck = {
   missingValue: number;
+};
+
+export type SCMValuesVerifyAllGPGCheck = {
+  perUnverifiedValue: number;
 };
 
 export type SCMValuesGitleaksFindingsCheck = {


### PR DESCRIPTION
For now, this will add 1 point of risk for every unsigned commit found in PR scope. [This value](https://github.com/JupiterOne/peril/blob/0e13b9a869f7b20050be4e92f8ecb0bccf4111d5/defaultConfig.json#L50) can be adjusted as needed over the course of the SLSA3: Verified History initiative to reflect updated risk valuations.